### PR TITLE
Bug/illegal state exception when skin has overrides

### DIFF
--- a/src/main/java/me/xhsun/guildwars2wrapper/model/v2/ItemStats.java
+++ b/src/main/java/me/xhsun/guildwars2wrapper/model/v2/ItemStats.java
@@ -4,6 +4,8 @@ package me.xhsun.guildwars2wrapper.model.v2;
 import me.xhsun.guildwars2wrapper.model.identifiable.NameableInt;
 import me.xhsun.guildwars2wrapper.model.v2.util.itemDetail.ItemAttributes;
 
+import java.util.List;
+
 /**
  * For more info on Itemstat API go <a href="https://wiki.guildwars2.com/wiki/API:2/itemstats">here</a><br/>
  * Itemstat model class
@@ -13,9 +15,9 @@ import me.xhsun.guildwars2wrapper.model.v2.util.itemDetail.ItemAttributes;
  * @since 2017-02-07
  */
 public class ItemStats extends NameableInt {
-	private ItemAttributes attributes;
+	private List<ItemAttributes> attributes;
 
-	public ItemAttributes getAttributes() {
+	public List<ItemAttributes> getAttributes() {
 		return attributes;
 	}
 }

--- a/src/main/java/me/xhsun/guildwars2wrapper/model/v2/Skin.java
+++ b/src/main/java/me/xhsun/guildwars2wrapper/model/v2/Skin.java
@@ -75,10 +75,16 @@ public class Skin extends NameableInt {
 			return type;
 		}
 
+		/**
+		 * Return null if type is Logging
+		 */
 		public ItemDetail.Weight getWeightClass() {
 			return weight_class;
 		}
 
+		/**
+		 * Return null if type is Logging
+		 */
 		public ItemDetail.Damage getDamageType() {
 			return damage_type;
 		}
@@ -94,13 +100,13 @@ public class Skin extends NameableInt {
 	public class DyeSlot {
 		@SerializedName("default")
 		private List<DefaultColor> _default;
-		private Map<String, DefaultColor> overrides;
+		private Map<String, List<DefaultColor>> overrides;
 
 		public List<DefaultColor> getDefault() {
 			return _default;
 		}
 
-		public Map<String, DefaultColor> getOverrides() {
+		public Map<String, List<DefaultColor>> getOverrides() {
 			return overrides;
 		}
 	}

--- a/src/main/java/me/xhsun/guildwars2wrapper/model/v2/util/Inventory.java
+++ b/src/main/java/me/xhsun/guildwars2wrapper/model/v2/util/Inventory.java
@@ -1,8 +1,10 @@
 package me.xhsun.guildwars2wrapper.model.v2.util;
 
+import me.xhsun.guildwars2wrapper.model.identifiable.IdentifiableInt;
 import me.xhsun.guildwars2wrapper.model.v2.Item;
 import me.xhsun.guildwars2wrapper.model.v2.ItemStats;
 import me.xhsun.guildwars2wrapper.model.v2.Skin;
+import me.xhsun.guildwars2wrapper.model.v2.util.itemDetail.ItemAttributes;
 
 import java.util.List;
 
@@ -19,7 +21,7 @@ public class Inventory extends Storage {
 	private List<Integer> infusions;
 	private List<Integer> upgrades;
 	private int skin;
-	private ItemStats stats;
+	private Stat stats;
 
 	public List<Integer> getInfusions() {
 		return infusions;
@@ -33,7 +35,7 @@ public class Inventory extends Storage {
 		return skin;
 	}
 
-	public ItemStats getStats() {
+	public Stat getStats() {
 		return stats;
 	}
 
@@ -67,5 +69,13 @@ public class Inventory extends Storage {
 		result = 31 * result + skin;
 		result = 31 * result + (stats != null ? stats.hashCode() : 0);
 		return result;
+	}
+
+	public class Stat extends IdentifiableInt {
+		private ItemAttributes attributes;
+
+		public ItemAttributes getAttributes() {
+			return attributes;
+		}
 	}
 }

--- a/src/test/java/me/xhsun/guildwars2wrapper/v2/GuildWars2V2URLTest.java
+++ b/src/test/java/me/xhsun/guildwars2wrapper/v2/GuildWars2V2URLTest.java
@@ -509,7 +509,7 @@ public class GuildWars2V2URLTest {
 	public void getAllItemID() {
 		try {
 			System.out.println(s.getAllItemID());
-			System.out.println(s.getItemInfo(new int[]{1}));
+			System.out.println(s.getItemInfo(new int[]{24}));
 		} catch (GuildWars2Exception e) {
 			handleException(e);
 		}


### PR DESCRIPTION
- Fix #39, which is caused by skins endpoint no longer providing just one override for each race (now it provides a list)

- Fix `IllegalStateException` caused by item stats endpoint providing a list of attributes (instead of one)

- `Inventory` no longer reference `ItemStats`, since the `stats` of a inventory only have one attribute

  - A new class, `Inventory.Stat`, is created to reflect this change

- Fix a broken test case caused by invalid item ID 